### PR TITLE
Replace ',' on '.' in cpu and mem. Fix #6

### DIFF
--- a/sensors/process.js
+++ b/sensors/process.js
@@ -60,8 +60,8 @@ var plugin = {
 				//console.log(currentLine);
 				var words = currentLine.split(" ");
 				if (typeof words[0] !== 'undefined' && typeof words[1] !== 'undefined' ) {
-					var cpu = words[0];
-					var mem = words[1];
+					var cpu = words[0].replace(',', '.');
+					var mem = words[1].replace(',', '.');
 					var offset = cpu.length + mem.length + 2;
 					var comm = currentLine.slice(offset);
 					// If we're on Mac then remove the path


### PR DESCRIPTION
In my system command 'ps' returns strings in format "0,0  1,6 com.apple.WebKit.WebContent". 
Function "parseFloat(stats[stat].cpu / os.cpus().length);" returns NaN when 'cpu' has ',' in float, and returns correct answer with '.'
