### PR TITLE
Adds dark theme

### DIFF
--- a/themes/dark.json
+++ b/themes/dark.json
@@ -1,0 +1,24 @@
+{
+	"name": "Dark",
+	"author": "boboman13",
+	"title": {
+		"fg": "#232323"
+	},
+	"chart": {
+		"fg": "#00A779",
+		"border": {
+			"type": "line",
+			"fg": "#232323"
+		}
+	},
+	"table": {
+		"fg": "#626262",
+		"border": {
+			"type": "line",
+			"fg": "#232323"
+		}
+	},
+	"footer": {
+		"fg": "white"
+	}
+}


### PR DESCRIPTION
This pull request adds a dark theme to the themes directory. I felt I had to create it because I personally use a custom Terminal (Mac), which has a partially opaque background and a lighter background color. It becomes a little bit harder to see lighter colors, and I figured somebody else could benefit from this theme.

Nice app! :+1: heres a screenshot of how the theme looks on my Mac.

![screenshot](http://upimg.me/01441947c956839cdb6ad423272ddb31.png)
