### PR TITLE
Add version, available via -V and --version

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ var App = function() {
 		os = require('os'),
 		cli = require('commander'),
 		upgrade = require('./upgrade.js'),
-		VERSION = '0.2.2';
+		VERSION = require('./package.json').version;
 
 	// Set up the commander instance and add the required options
 	cli.option('-t, --theme [name]', 'set the vtop theme [parallax|brew|wizard|dark]', 'parallax')


### PR DESCRIPTION
This adds a way to see the current version of vtop, you just need to increment that variable when you make new releases :)
