### PR TITLE
Fix reported memory usage on Linux

### DIFF
--- a/sensors/memory.js
+++ b/sensors/memory.js
@@ -18,10 +18,10 @@ var plugin = {
 	 * @type {String}
 	 */
 	type: 'chart',
-		/**
-		 * The default interval time in ms that this plugin should be polled.
-		 * More costly benchmarks should be polled less frequently.
-		 */
+	/**
+	 * The default interval time in ms that this plugin should be polled.
+	 * More costly benchmarks should be polled less frequently.
+	 */
 	interval: 200,
 
 	initialized: false,
@@ -30,9 +30,9 @@ var plugin = {
 
 	isLinux: _os.platform().indexOf('linux') != -1,
 
-		/**
-		 * Grab the current value, from 0-100
-		 */
+	/**
+	 * Grab the current value, from 0-100
+	 */
 	poll: function() {
 		var computeUsage = function(used, total) {
 			return Math.round(100 * (used / total));

--- a/sensors/memory.js
+++ b/sensors/memory.js
@@ -18,40 +18,41 @@ var plugin = {
 	 * @type {String}
 	 */
 	type: 'chart',
-	/**
-	 * The default interval time in ms that this plugin should be polled.
-	 * More costly benchmarks should be polled less frequently.
-	 */
+		/**
+		 * The default interval time in ms that this plugin should be polled.
+		 * More costly benchmarks should be polled less frequently.
+		 */
 	interval: 200,
 
 	initialized: false,
 
 	currentValue: 0,
 
-    isLinux: _os.platform().indexOf('linux') != -1,
+	isLinux: _os.platform().indexOf('linux') != -1,
 
-	/**
-	 * Grab the current value, from 0-100
-	 */
+		/**
+		 * Grab the current value, from 0-100
+		 */
 	poll: function() {
-        var computeUsage = function(used, total) {
-            return Math.round(100 * (used / total));
-        };
+		var computeUsage = function(used, total) {
+			return Math.round(100 * (used / total));
+		};
 
-        if (plugin.isLinux) {
-            child.exec('free -m', function(err, stdout, stderr) {
-                var data = stdout.split('\n')[1].replace(/[\s\n\r]+/g, ' ').split(' ');
-                
-                var used = parseInt(data[2]);
-                var total = parseInt(data[1]);
-                plugin.currentValue = computeUsage(used, total);
-            });
-        } else {
-            plugin.currentValue = Math.round((1 - os.freememPercentage()) * 100);
-        }
+		if (plugin.isLinux) {
+			child.exec('free -m', function(err, stdout, stderr) {
+				var data = stdout.split('\n')[1].replace(/[\s\n\r]+/g, ' ').split(' ');
+
+				var used = parseInt(data[2]);
+				var total = parseInt(data[1]);
+				plugin.currentValue = computeUsage(used, total);
+			});
+		} else {
+			plugin.currentValue = Math.round((1 - os.freememPercentage()) * 100);
+		}
 
 		plugin.initialized = true;
 	}
 };
+
 module.exports = exports = plugin;
 

--- a/sensors/memory.js
+++ b/sensors/memory.js
@@ -38,7 +38,7 @@ var plugin = {
             return Math.round(100 * (used / total));
         };
 
-		if (plugin.isLinux) {
+        if (plugin.isLinux) {
             child.exec('free -m', function(err, stdout, stderr) {
                 var data = stdout.split('\n')[1].replace(/[\s\n\r]+/g, ' ').split(' ');
                 
@@ -54,3 +54,4 @@ var plugin = {
 	}
 };
 module.exports = exports = plugin;
+


### PR DESCRIPTION
The os-utils module reports erroneous used memory percentage, in
particular, it considers memory used by the kernel's disk caching
subsystem as used memory, when it should in reality be considered free
as it is transparently let go when memory is low. See
http://linuxatemyram.com.

This changeset fixes this by detecting if we're on Linux, and if so,
runs `free -m` in a child process and screenscrapes its output. os-utils
does provide a .freeCommand() function which is supposed to be doing
this, but it also returns erroneous numbers.

Before:
![screenshot from 2015-01-15 09 29 43](https://cloud.githubusercontent.com/assets/968875/5754637/b69a89e8-9c9b-11e4-93fb-3fae8f7b8d29.png)
After:
![screenshot from 2015-01-15 09 30 18](https://cloud.githubusercontent.com/assets/968875/5754639/bb9ff234-9c9b-11e4-8f96-b15923812c56.png)

(shown with gnome-system-monitor on the side for comparison)