### PR TITLE
Overriding .npmrc --color option

### DIFF
--- a/upgrade.js
+++ b/upgrade.js
@@ -18,7 +18,7 @@ var upgrade = function() {
 				var current = require('./package.json').version;
 
 				var child_process = require('child_process');
-				var ps = child_process.exec('npm info vtop', function (error, stdout, stderr) {
+				var ps = child_process.exec('npm --color=false info vtop', function (error, stdout, stderr) {
 					var output = eval('(' + stdout + ')');
 					if (output['dist-tags']['latest'] != current) {
 						callback(output['dist-tags']['latest']);


### PR DESCRIPTION
If you have set an .npmrc with the --color option, then vtop will fail at startup with the following error.

```
SyntaxError: Unexpected token ILLEGAL
```

The fix is to explicitly state that the npm command in the update.js file should use no colors.