### PR TITLE
Properly handle errors from npm info

### DIFF
--- a/upgrade.js
+++ b/upgrade.js
@@ -20,7 +20,8 @@ var upgrade = (function () {
         var childProcess = require('child_process')
         childProcess.exec('npm --color=false info vtop', function (error, stdout, stderr) {
           if (error) {
-            console.error(error)
+            callback(false)
+            return
           }
           var output = safeEval('(' + stdout + ')')
           if (output['dist-tags']['latest'] !== current) {


### PR DESCRIPTION
Currently, execution would continue, so "()" would be `safeEval`ed, causing a crash.

Instead, gracefully handle the failure, just like errors from outside the `childProcess.exec` callback (which are handled by `try`/`catch`).