### PR TITLE
[Solarized] Add unofficial solarized dark theme

### DIFF
--- a/themes/solarized.json
+++ b/themes/solarized.json
@@ -1,0 +1,33 @@
+{
+	"name": "Solarized",
+	"author": "Chris Mills",
+	"title": {
+		"fg": "#2aa198"
+	},
+	"chart": {
+		"fg": "#5f8700",
+		"border": {
+			"type": "line",
+			"fg": "#93a1a1"
+		}
+	},
+	"table": {
+		"fg": "#626262",
+		"items": {
+			"selected": {
+				"bg": "#00afaf",
+				"fg": "#073642"
+			},
+			"item": {
+				"fg": "#93a1a1"
+			}
+		},
+		"border": {
+			"type": "line",
+			"fg": "#93a1a1"
+		}
+	},
+	"footer": {
+		"fg": "#00afaf"
+	}
+}


### PR DESCRIPTION
I've noticed that there's not a solarized dark theme for vtop. Without it when people reference this repository in various popular dotfile repositories and screenshots if often looks out of place. This is basic and is obviously not official.

Signed-off-by: Chris M <millscj01@gmail.com>