### PR TITLE
[refs #114] Move husky to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,13 @@
     "commander": "2.11.0",
     "drawille": "1.1.0",
     "glob": "7.1.2",
-    "husky": "^0.14.3",
     "os-utils": "0.0.14",
     "read": "1.0.7",
     "sudo": "1.0.3",
     "use-strict": "^1.0.1"
+  },
+  "devDependencies": {
+    "standard": "^12.0.1",
+    "husky": "^0.14.3"
   }
 }


### PR DESCRIPTION
The current husky precommit task is to run standard which also hasn't
been included in devDependencies. I've added both so it's not required
as a general dependency.

This should resolve the ticket #114 also.

Signed-off-by: Chris M <>