### PR TITLE
Fixing footer appearance after terminal resize

### DIFF
--- a/app.js
+++ b/app.js
@@ -568,6 +568,7 @@ const App = ((() => {
         })
         processList.append(processListSelection)
         processListSelection.focus()
+        drawFooter() //Footer appears even after resizing the terminal
         screen.render()
       }
 


### PR DESCRIPTION
The footer initially disappeared after resizing the terminal. This update keeps the footer even after resizing. The issue is listed here --- https://github.com/MrRio/vtop/issues/139